### PR TITLE
Add optional date key. Resolves #1

### DIFF
--- a/content_scripts/copy_with_context.js
+++ b/content_scripts/copy_with_context.js
@@ -19,6 +19,7 @@
 				formattedText = formattedText.replace('{CWC_TEXT}', selectedText);
 				formattedText = formattedText.replace('{CWC_TITLE}', title);
 				formattedText = formattedText.replace('{CWC_URL}', url);
+				formattedText = formattedText.replace('{CWC_DATE}', Date());
 
 				navigator.clipboard.writeText(formattedText)
 					.catch(error => console.error(`Failed to write to clipboard: ${error}`));

--- a/options.html
+++ b/options.html
@@ -25,6 +25,7 @@
 		<p>{CWC_TEXT} = selected text</p>
 		<p>{CWC_TITLE} = page title</p>
 		<p>{CWC_URL} = page URL</p>
+		<p>{CWC_DATE} = current date and time</p>
 		<textarea id="formatting" rows="5" cols="50"></textarea>
 		</br>
 		<button type="submit">Save</button>


### PR DESCRIPTION
Resolves #1 

This branch adds an optional {CWC_DATE} key to keep track off when the text was copied.

The current implementation uses the default Date object without any special formatting to produce the output, i.e.

`"Sat Aug 15 2020 23:33:21 GMT+0200 (Central European Summer Time)"
`